### PR TITLE
Add download-dir option for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ And then execute:
 
 TODO: Write usage instructions here
 
+Incoming events accept the following keys:
+
+Required:
+	url: The URL of the torrent file, or magnet link data.
+
+Optional:
+	paused: true/false, Should the torrent start paused or now
+        download-dir: destination directory for the torrent data
+        bandwidthPriority: integer, the priority to add the torrent with
+
+
 ## Development
 
 Running `rake` will clone and set up Huginn in `spec/huginn` to run the specs of the Gem in Huginn as if they would be build-in Agents. The desired Huginn repository and branch can be modified in the `Rakefile`:

--- a/lib/huginn_transmission_agent/transmission_agent.rb
+++ b/lib/huginn_transmission_agent/transmission_agent.rb
@@ -43,7 +43,7 @@ module Agents
     def receive(incoming_events)
       incoming_events.each do |event|
         log "Adding torrent: #{event.payload['description']}"
-        client.create(event.payload['url'])
+        client.create(event.payload['url'], event.payload['download-dir'], event.payload['bandwidthPriority'], event.payload['paused'])
       end
     end
 

--- a/lib/transmission_api/client.rb
+++ b/lib/transmission_api/client.rb
@@ -54,26 +54,15 @@ class TransmissionApi::Client
     response["arguments"]["torrents"].first
   end
 
-  def create(filename, download_dir = nil, bandwidthPriority = nil, paused = nil)
+  def create(filename, download_dir = nil, bandwidth_priority = nil, paused = nil)
     log "add_torrent: #{filename}"
 
     data = {
-          :filename => filename,
-	  :paused => paused,
-       } 
-
-    # add some of the optional parameters if provided
-    if (download_dir != nil)
-    	data["download-dir"] = download_dir
-    end
-    
-    if (bandwidthPriority != nil)
-    	data["bandwidthPriority"] = bandwidthPriority
-    end
-    
-    if (paused != nil)
-    	data["paused"] = paused
-    end
+      :filename => filename,
+      :paused => paused,
+      :"download-dir" => download_dir,
+      :bandwidthPrioity => bandwidth_priority
+    }.compact 
     
     response =
       post(

--- a/lib/transmission_api/client.rb
+++ b/lib/transmission_api/client.rb
@@ -54,15 +54,31 @@ class TransmissionApi::Client
     response["arguments"]["torrents"].first
   end
 
-  def create(filename)
+  def create(filename, download_dir = nil, bandwidthPriority = nil, paused = nil)
     log "add_torrent: #{filename}"
 
+    data = {
+          :filename => filename,
+	  :paused => paused,
+       } 
+
+    # add some of the optional parameters if provided
+    if (download_dir != nil)
+    	data["download-dir"] = download_dir
+    end
+    
+    if (bandwidthPriority != nil)
+    	data["bandwidthPriority"] = bandwidthPriority
+    end
+    
+    if (paused != nil)
+    	data["paused"] = paused
+    end
+    
     response =
       post(
         :method => "torrent-add",
-        :arguments => {
-          :filename => filename
-        }
+        :arguments => data
       )
 
     response["arguments"]["torrent-added"]


### PR DESCRIPTION
This PR adds support for optionally having a download-dir property to direct where downloads should go to.

It also supports paused, and bandwidthPriority properties.